### PR TITLE
Prevent segmentation violation upon 'primecoind exit'

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -125,16 +125,11 @@ void Shutdown()
 void DetectShutdownThread(boost::thread_group* threadGroup)
 {
     // Tell the main threads to shutdown.
-    while (!fRequestShutdown)
-    {
-        MilliSleep(200);
-        if (fRequestShutdown)
-            threadGroup->interrupt_all();
-    }
+    while (!fRequestShutdown) MilliSleep(200);
  
-   // and tell the bitcoin generation thread to shutdown cleanly, so that
-   // we don't segfault :-)
-   GenerateBitcoins(false, NULL);
+    if(fGenerate) GenerateBitcoins(false, NULL);
+    threadGroup->interrupt_all();
+
 }
 
 void HandleSIGTERM(int)


### PR DESCRIPTION
If primecoind is generating coins at the time of 'primecoind stop',
it can/will segfault:

Core was generated by `./primecoind'.
Program terminated with signal 11, Segmentation fault.
    (this=0x7f3a64000d20) at prime.cpp:552
552         unsigned int nPrime = vPrimes[nPrimeSeq];

This occurs because in thread number 2, exit() gets called,
which in turns calls atexit() / on_exit() handlers. Boost registers
some handlers to free memory (OpenSSL specifically which causes the
above to result in segfaulting.)

So the fix is to stop the thread group in GenerateCoins() by telling
it to not generate coins, which results in a clean process exit.

The above crash can be reproduced by running primecoind in coin
generation mode, and stopping it with 'primecoind stop' under
Ubuntu 13.04, latest apt-get update / apt-get upgrade -y.

(Tips welcome, ARhURiSGy9NMiXQr2Q9h3AL8qPntcsSKkF - it will make up
for the orphans I'm seeing :-( )
