### PR TITLE
 Fix compile error with init.cpp

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -127,7 +127,7 @@ void DetectShutdownThread(boost::thread_group* threadGroup)
     // Tell the main threads to shutdown.
     while (!fRequestShutdown) MilliSleep(200);
  
-    if(fGenerate) GenerateBitcoins(false, NULL);
+    GenerateBitcoins(false, NULL);
     threadGroup->interrupt_all();
 
 }


### PR DESCRIPTION
The fGenerate flag is not defined in init.cpp. 

init.cpp: In function ‘void DetectShutdownThread(boost::thread_group*)’:
init.cpp:131:8: error: ‘fGenerate’ was not declared in this scope

I tried importing rpcmining.cpp that defines the flag, but it did not work. Removing the reference to the flag did solve the compile problem.
Is the flag needed? Setting GenerateBicoins to (false and null) does not appear to effect anything in the shutdown if the generation flag is false.
