### PR TITLE
Fix block submission using getwork RPC command

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -192,6 +192,12 @@ Value getwork(const Array& params, bool fHelp)
         pblock->vtx[0].vin[0].scriptSig = mapNewBlock[pdata->hashMerkleRoot].second;
         pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 
+        // Deserialize PrimeChainMultiplier
+        unsigned char primemultiplier[48];
+        memcpy(primemultiplier, &pdata->bnPrimeChainMultiplier, 48);
+        CDataStream ssMult(BEGIN(primemultiplier), END(primemultiplier), SER_NETWORK, PROTOCOL_VERSION);
+        ssMult >> pblock->bnPrimeChainMultiplier;
+
         return CheckWork(pblock, *pwalletMain, *pMiningKey);
     }
 }


### PR DESCRIPTION
Passing the prime chain multiplier in "getwork" RPC command was fixed in
order to be usable for block submission.

Passing the multiplier as a CBigNum is similar to what is used in "submitblock" command except that getwork uses swapped endian. 
It would be helpful to have this fix in the main fork because compared to "submitblock/getblocktemplate", using "getwork"  simplifies the code of the miner, not requiring to build the vtx for the block. 
