### PR TITLE
Fix compilation on FreeBSD where libdl is part of libc

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -19,6 +19,8 @@ DEFS=-DBOOST_SPIRIT_THREADSAFE -D_FILE_OFFSET_BITS=64
 DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
 LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH))
 
+TARGET_OS=$(shell uname -s)
+
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
 
 LMODE = dynamic
@@ -62,8 +64,10 @@ endif
 LIBS+= \
  -Wl,-B$(LMODE2) \
    -l z \
-   -l dl \
    -l pthread
+ifneq (${TARGET_OS}, FreeBSD)
+	LIBS += -l dl
+endif
 
 
 # Hardening


### PR DESCRIPTION
On FreeBSD, libdl is part of libc. Take some OS detection logic from src/leveldb/Makefile to make the right decision here and not -ldl here.
