### PR TITLE
Replace dns seed ppcoin.net with primecoin.info

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1200,9 +1200,9 @@ static const char *strMainNetDNSSeed[][2] = {
 };
 
 static const char *strTestNetDNSSeed[][2] = {
-    {"primecoin.info", "tnseed.primecoin.info"},
+    {"primecoin.info", "testseed.primecoin.info"},
     {"primeseedtn.muuttuja.org", "primeseedtn.muuttuja.org"},
-    {"primecoin.org", "tnseed.primecoin.org"},
+    {"primecoin.org", "seed.testnet.primecoin.org"},
     {"coinsforall.io", "xpmtestnet.dnsseed.coinsforall.io"},
     {NULL, NULL}
 };

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1192,7 +1192,7 @@ void MapPort(bool)
 // The first name is used as information source for addrman.
 // The second name should resolve to a list of seed addresses.
 static const char *strMainNetDNSSeed[][2] = {
-    {"ppcoin.net", "seed.ppcoin.net"},
+    {"primecoin.info", "seed.primecoin.info"},
     {"primeseed.muuttuja.org", "primeseed.muuttuja.org"},
     {"primecoin.org", "seed.primecoin.org"},
     {"coinsforall.io", "xpm.dnsseed.coinsforall.io"},
@@ -1200,7 +1200,7 @@ static const char *strMainNetDNSSeed[][2] = {
 };
 
 static const char *strTestNetDNSSeed[][2] = {
-    {"ppcoin.net", "tnseed.ppcoin.net"},
+    {"primecoin.info", "tnseed.primecoin.info"},
     {"primeseedtn.muuttuja.org", "primeseedtn.muuttuja.org"},
     {"primecoin.org", "tnseed.primecoin.org"},
     {NULL, NULL}

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1203,6 +1203,7 @@ static const char *strTestNetDNSSeed[][2] = {
     {"primecoin.info", "tnseed.primecoin.info"},
     {"primeseedtn.muuttuja.org", "primeseedtn.muuttuja.org"},
     {"primecoin.org", "tnseed.primecoin.org"},
+    {"coinsforall.io", "xpmtestnet.dnsseed.coinsforall.io"},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
New dns seed at seed.primecoin.info.
ppcoin.net dns service will be decommissioned.