### PR TITLE
Rate limit getblocks to work around sync performance issue

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -2033,6 +2033,7 @@ public:
 
     void Set(const CBlockIndex* pindex)
     {
+        printf("block locator make @ epoch=%f height=%d\n", GetTimeMicros() * 0.000001, pindex->nHeight);
         vHave.clear();
         int nStep = 1;
         while (pindex)
@@ -2046,6 +2047,7 @@ public:
                 nStep *= 2;
         }
         vHave.push_back(hashGenesisBlock);
+        printf("block locator made @ epoch=%f\n", GetTimeMicros() * 0.000001);
     }
 
     int GetDistanceBack()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -88,8 +88,16 @@ void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
     // Filter out duplicate requests
     if (pindexBegin == pindexLastGetBlocksBegin && hashEnd == hashLastGetBlocksEnd)
         return;
+    // Workaround to sync performance issue: rate limit getblocks (block locator is expensive to construct)
+    if (nLastGetBlocksTime + 5 > GetTime() && nLastGetBlocksHeight + 250 > pindexBegin->nHeight) {
+        printf("getblocks from height=%d rate limited last=%d\n", pindexBegin->nHeight, nLastGetBlocksHeight);
+        return;
+    }
     pindexLastGetBlocksBegin = pindexBegin;
     hashLastGetBlocksEnd = hashEnd;
+    nLastGetBlocksTime = GetTime();
+    nLastGetBlocksHeight = pindexBegin->nHeight;
+    printf("getblocks from height=%d\n", pindexBegin->nHeight);
 
     PushMessage("getblocks", CBlockLocator(pindexBegin), hashEnd);
 }

--- a/src/net.h
+++ b/src/net.h
@@ -209,6 +209,8 @@ public:
     uint256 hashContinue;
     CBlockIndex* pindexLastGetBlocksBegin;
     uint256 hashLastGetBlocksEnd;
+    int64 nLastGetBlocksTime;
+    int nLastGetBlocksHeight;
     int nStartingHeight;
     bool fStartSync;
 
@@ -252,6 +254,8 @@ public:
         hashContinue = 0;
         pindexLastGetBlocksBegin = 0;
         hashLastGetBlocksEnd = 0;
+        nLastGetBlocksTime = 0;
+        nLastGetBlocksHeight = -1;
         nStartingHeight = -1;
         fStartSync = false;
         fGetAddr = false;


### PR DESCRIPTION
Block locator is now very expensive to construct (3M+ blocks). Granted it is done in a very lazy fashion that's costly but it's built into the network protocol. The sync can end up spending a majority of time preparing the locators for getblocks message.

The workaround is to rate limit getblocks messages with minimal disruption to the network protocol and the sync process. 