### PR TITLE
delete address index and tx index when blocks are disconnected

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -290,6 +290,25 @@ bool CBlockTreeDB::AddAddrIndex(const std::vector<std::pair<uint160, CExtDiskTxP
     return WriteBatch(batch, true);
 }
 
+bool CBlockTreeDB::EraseTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >&vect) {
+    CDBBatch batch(*this);
+    for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
+        batch.Erase(std::make_pair(DB_TXINDEX, it->first));
+    return WriteBatch(batch);
+}
+
+bool CBlockTreeDB::EraseAddrIndex(const std::vector<std::pair<uint160, CExtDiskTxPos> > &list) {
+    unsigned char foo[0];
+    CDBBatch batch(*this);
+    for (std::vector<std::pair<uint160, CExtDiskTxPos> >::const_iterator it=list.begin(); it!=list.end(); it++) {
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << salt;
+        ss << it->first;
+        batch.Erase(std::make_pair(std::make_pair('a', UintToArith256(ss.GetHash()).GetLow64()), it->second));
+    }
+    return WriteBatch(batch, true);
+}
+
 bool CBlockTreeDB::WriteFlag(const std::string &name, bool fValue) {
     return Write(std::make_pair(DB_FLAG, name), fValue ? '1' : '0');
 }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -171,6 +171,8 @@ public:
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &vect);
     bool ReadAddrIndex(uint160 addrid, std::vector<CExtDiskTxPos> &list);
     bool AddAddrIndex(const std::vector<std::pair<uint160, CExtDiskTxPos> > &list);
+    bool EraseTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >&vect);
+    bool EraseAddrIndex(const std::vector<std::pair<uint160, CExtDiskTxPos> > &list);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex);


### PR DESCRIPTION
In the dev0.16 branch, the address index and tx index are added when a block is connected, but they are not removed if blocks are disconnected from a forked chain. This may lead to incorrect balance shown on the explorer. This pull request solves this problem.