### PR TITLE
Show min relay fee in rpc 'sendrawtransaction' error message

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -722,7 +722,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
         // No transactions are allowed below minRelayTxFee except from disconnected blocks
         if (!bypass_limits && nModifiedFees < ::minRelayTxFee.GetFee(nSize)) {
-            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, strprintf("min relay fee (%g XPM) not met", ::minRelayTxFee.GetFee(nSize)*1./COIN));
+            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, strprintf("Required minimum fee for this transaction is %g", ::minRelayTxFee.GetFee(nSize)*1./COIN));
         }
 
         if (nAbsurdFee && nFees > nAbsurdFee)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -722,7 +722,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
         // No transactions are allowed below minRelayTxFee except from disconnected blocks
         if (!bypass_limits && nModifiedFees < ::minRelayTxFee.GetFee(nSize)) {
-            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "min relay fee not met");
+            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, strprintf("min relay fee (%g XPM) not met", ::minRelayTxFee.GetFee(nSize)*1./COIN));
         }
 
         if (nAbsurdFee && nFees > nAbsurdFee)


### PR DESCRIPTION
Show the minimum relay fee in the error message if min fee is not met.