### PR TITLE
Store primechain type and length as mutable in block header

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -267,6 +267,8 @@ public:
         nBits          = block.nBits;
         nNonce         = block.nNonce;
         bnPrimeChainMultiplier = block.bnPrimeChainMultiplier;
+        nPrimeChainType = block.nPrimeChainType;
+        nPrimeChainLength = block.nPrimeChainLength;
     }
 
     CDiskBlockPos GetBlockPos() const {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -16,10 +16,8 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     return prime.GetPrimeWorkRequired(pindexLast, pblock, params);
 }
 
-bool CheckProofOfWork(uint256 hashBlockHeader, unsigned int nBits, const CBigNum& bnPrimeChainMultiplier, const Consensus::Params& consensus_params)
+bool CheckProofOfWork(uint256 hashBlockHeader, unsigned int nBits, const CBigNum& bnPrimeChainMultiplier, unsigned int& nChainType, unsigned int& nChainLength, const Consensus::Params& consensus_params)
 {
-    unsigned int nChainType = 0;
-    unsigned int nChainLength = 0;
     if (!CheckPrimeProofOfWork(hashBlockHeader, nBits, bnPrimeChainMultiplier, nChainType, nChainLength, consensus_params))
         return error("CheckProofOfWork() : check failed for prime proof-of-work");
     

--- a/src/pow.h
+++ b/src/pow.h
@@ -19,6 +19,6 @@ class uint256;
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
-bool CheckProofOfWork(uint256 hashBlockHeader, unsigned int nBits, const CBigNum& bnPrimeChainMultiplier, const Consensus::Params& consensus_params);
+bool CheckProofOfWork(uint256 hashBlockHeader, unsigned int nBits, const CBigNum& bnPrimeChainMultiplier, unsigned int& nChainType, unsigned int& nChainLength, const Consensus::Params& consensus_params);
 
 #endif // BITCOIN_POW_H

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -52,6 +52,10 @@ public:
     // BiTwin Chain:                    hash * multiplier * 2**k +/- 1
     CBigNum bnPrimeChainMultiplier;
 
+    // memory only
+    mutable uint32_t nPrimeChainType;
+    mutable uint32_t nPrimeChainLength;
+
     CBlockHeader()
     {
         SetNull();
@@ -79,6 +83,8 @@ public:
         nBits = 0;
         nNonce = 0;
         bnPrimeChainMultiplier = 0;
+        nPrimeChainType = 0;
+        nPrimeChainLength = 0;
     }
 
     bool IsNull() const


### PR DESCRIPTION
* Clean up AddToBlockIndex() to not check proof-of-work itself
* Refer to earlier commit b2b793b1d96ee2c06925fbf9bdead629b04af0b8